### PR TITLE
DCS-383 Converting 500 response into correct 400 

### DIFF
--- a/src/main/java/net/syscon/elite/service/BookingService.java
+++ b/src/main/java/net/syscon/elite/service/BookingService.java
@@ -651,7 +651,7 @@ public class BookingService {
     }
 
     private Set<String> getCaseLoadIdForUserIfRequired() {
-        return isViewAllBookings() ? null : caseLoadService.getCaseLoadIdsForUser(authenticationFacade.getCurrentUsername(), false);
+        return isViewAllBookings() ? Set.of() : caseLoadService.getCaseLoadIdsForUser(authenticationFacade.getCurrentUsername(), false);
     }
 
     private List<OffenderSentenceDetail> getOffenderSentenceDetails(final List<OffenderSentenceDetailDto> offenderSentenceSummary) {


### PR DESCRIPTION
This occurs when the user is an RO with global search,  has no active caseloads (as most won't) and provides no offender numbers