### PR TITLE
PAT-593 removing cache on offender booking lookup. This endpoint is u…

### DIFF
--- a/src/main/java/net/syscon/elite/repository/impl/InmateRepositoryImpl.java
+++ b/src/main/java/net/syscon/elite/repository/impl/InmateRepositoryImpl.java
@@ -633,7 +633,6 @@ public class InmateRepositoryImpl extends RepositoryBase implements InmateReposi
     }
 
     @Override
-    @Cacheable("findInmate")
     public Optional<InmateDetail> findInmate(final Long bookingId) {
         final var builder = queryBuilderFactory.getQueryBuilder(getQuery("FIND_INMATE_DETAIL"), inmateDetailsMapping);
         final var sql = builder.build();

--- a/src/main/java/net/syscon/elite/web/config/CacheConfig.java
+++ b/src/main/java/net/syscon/elite/web/config/CacheConfig.java
@@ -72,7 +72,6 @@ public class CacheConfig implements CachingConfigurer {
 
         config.addCache(config("findLocationsByAgencyAndType", 1000, locationTimeoutSeconds, MemoryStoreEvictionPolicy.LRU));
         config.addCache(config("searchForOffenderBookings", 1000, offenderSearchTimeoutSeconds, MemoryStoreEvictionPolicy.LRU));
-        config.addCache(config("findInmate", 1000, bookingTimeoutSeconds, MemoryStoreEvictionPolicy.LRU));
         config.addCache(config("basicInmateDetail", 1000, bookingTimeoutSeconds, MemoryStoreEvictionPolicy.LRU));
 
         config.addCache(config("bookingAssessments", 200, assessmentTimeoutSeconds, MemoryStoreEvictionPolicy.LRU));


### PR DESCRIPTION
…sed to lookup offender details when offender events are received in pathfinder.

The stats from production show this cache is not performing well:
"findInmate": " 1000 / 1000  hits:2783 misses:25593 exp: 176 notfound:25417 bytes:17689928",