### PR TITLE
DT-601 changes to support retrieval of references codes in relation court hearing creation.

### DIFF
--- a/src/main/java/net/syscon/elite/repository/jpa/model/CaseStatus.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/CaseStatus.java
@@ -5,11 +5,16 @@ import lombok.NoArgsConstructor;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
+import static net.syscon.elite.repository.jpa.model.CaseStatus.CASE_STS;
+
 @Entity
-@DiscriminatorValue(ReferenceCode.CASE_STS)
+@DiscriminatorValue(CASE_STS)
 @NoArgsConstructor
 public class CaseStatus extends ReferenceCode {
+
+    static final String CASE_STS = "CASE_STS";
+
     public CaseStatus(final String code, final String description) {
-        super(ReferenceCode.CASE_STS, code, description);
+        super(CASE_STS, code, description);
     }
 }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/DisciplinaryAction.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/DisciplinaryAction.java
@@ -10,6 +10,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue(ReferenceCode.MLTY_DISCP)
 @NoArgsConstructor
 public class DisciplinaryAction extends ReferenceCode {
+
+    public static final ReferenceCode.Pk COURT_MARTIAL = new ReferenceCode.Pk(ReferenceCode.MLTY_DISCP, "CM");
+
     public DisciplinaryAction(final String code, final String description) {
         super(ReferenceCode.MLTY_DISCP, code, description);
     }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/EventStatus.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/EventStatus.java
@@ -12,6 +12,8 @@ public class EventStatus extends ReferenceCode {
 
     static final String EVENT_STS = "EVENT_STS";
 
+    public static final ReferenceCode.Pk SCHEDULED = new Pk(EVENT_STS, "SCH");
+
     public EventStatus(final String code, final String description) {
         super(EVENT_STS, code, description);
     }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/EventType.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/EventType.java
@@ -12,6 +12,8 @@ public class EventType extends ReferenceCode {
 
     static final String EVENT_TYPE = "EVENT_TYPE";
 
+    public static final ReferenceCode.Pk COURT = new ReferenceCode.Pk(EVENT_TYPE, "CRT");
+
     public EventType(final String code, final String description) {
         super(EVENT_TYPE, code, description);
     }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/LegalCaseType.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/LegalCaseType.java
@@ -6,10 +6,13 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
 @Entity
-@DiscriminatorValue(ReferenceCode.LEG_CASE_TYP)
+@DiscriminatorValue(LegalCaseType.LEG_CASE_TYP)
 @NoArgsConstructor
 public class LegalCaseType extends ReferenceCode {
+
+    static final String LEG_CASE_TYP = "LEG_CASE_TYP";
+
     public LegalCaseType(final String code, final String description) {
-        super(ReferenceCode.LEG_CASE_TYP, code, description);
+        super(LEG_CASE_TYP, code, description);
     }
 }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/MilitaryBranch.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/MilitaryBranch.java
@@ -9,6 +9,9 @@ import javax.persistence.Entity;
 @DiscriminatorValue(ReferenceCode.MLTY_BRANCH)
 @NoArgsConstructor
 public class MilitaryBranch extends ReferenceCode {
+
+    public static final ReferenceCode.Pk ARMY = new ReferenceCode.Pk(ReferenceCode.MLTY_BRANCH, "ARM");
+
     public MilitaryBranch(final String code, final String description) {
         super(ReferenceCode.MLTY_BRANCH, code, description);
     }

--- a/src/main/java/net/syscon/elite/repository/jpa/model/OffenderCourtCase.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/OffenderCourtCase.java
@@ -26,8 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static net.syscon.elite.repository.jpa.model.ReferenceCode.CASE_STS;
-import static net.syscon.elite.repository.jpa.model.ReferenceCode.LEG_CASE_TYP;
+import static net.syscon.elite.repository.jpa.model.CaseStatus.CASE_STS;
+import static net.syscon.elite.repository.jpa.model.LegalCaseType.LEG_CASE_TYP;
 import static org.hibernate.annotations.NotFoundAction.IGNORE;
 
 @Data

--- a/src/main/java/net/syscon/elite/repository/jpa/model/ReferenceCode.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/model/ReferenceCode.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.Inheritance;
 import java.io.Serializable;
 
@@ -16,16 +18,26 @@ import java.io.Serializable;
 @Entity(name = "REFERENCE_CODES")
 @DiscriminatorColumn(name = "domain")
 @Inheritance
+@IdClass(ReferenceCode.Pk.class)
 public abstract class ReferenceCode implements Serializable {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Pk implements Serializable {
+        private String domain;
+
+        private String code;
+    }
+
     @Id
+    @Column(insertable = false, updatable = false)
     private String domain;
+
     @Id
     private String code;
 
     private String description;
 
-    static final String CASE_STS = "CASE_STS";
-    static final String LEG_CASE_TYP = "LEG_CASE_TYP";
     static final String MLTY_BRANCH = "MLTY_BRANCH";
     static final String MLTY_WZONE = "MLTY_WZONE";
     static final String MLTY_DSCHRG = "MLTY_DSCHRG";

--- a/src/main/java/net/syscon/elite/repository/jpa/repository/ReferenceCodeRepository.java
+++ b/src/main/java/net/syscon/elite/repository/jpa/repository/ReferenceCodeRepository.java
@@ -1,0 +1,7 @@
+package net.syscon.elite.repository.jpa.repository;
+
+import net.syscon.elite.repository.jpa.model.ReferenceCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ReferenceCodeRepository<T extends ReferenceCode> extends CrudRepository<T, ReferenceCode.Pk> {
+}

--- a/src/test/java/net/syscon/elite/repository/jpa/repository/CourtEventRepositoryTest.java
+++ b/src/test/java/net/syscon/elite/repository/jpa/repository/CourtEventRepositoryTest.java
@@ -36,16 +36,22 @@ public class CourtEventRepositoryTest {
     private AgencyLocationRepository agencyRepository;
 
     @Autowired
+    private ReferenceCodeRepository<EventStatus> eventStatusRepository;
+
+    @Autowired
+    private ReferenceCodeRepository<EventType> eventTypeRepository;
+
+    @Autowired
     private TestEntityManager entityManager;
 
     @Test
     void court_event_can_be_saved_and_retrieved() {
         var commentText = "Comment text for court event";
         var courtLocation = agencyRepository.findById("COURT1").orElseThrow();
-        var courtEventType = new EventType("CRT", "Court Action");
+        var courtEventType = eventTypeRepository.findById(EventType.COURT).orElseThrow();
         var directionCode = "OUT";
         var eventDate = LocalDate.now();
-        var eventStatus = new EventStatus("SCH", "Scheduled (Approved)");
+        var eventStatus = eventStatusRepository.findById(EventStatus.SCHEDULED).orElseThrow();
         var startTime = eventDate.atTime(12, 0);
         var nextEventRequestFlag = "X";
         var offenderBooking = offenderBookingRepository.findById(-1L).orElseThrow();

--- a/src/test/java/net/syscon/elite/repository/jpa/repository/OffenderBookingRepositoryTest.java
+++ b/src/test/java/net/syscon/elite/repository/jpa/repository/OffenderBookingRepositoryTest.java
@@ -36,6 +36,18 @@ public class OffenderBookingRepositoryTest {
     private AgencyLocationRepository agencyLocationRepository;
 
     @Autowired
+    private ReferenceCodeRepository<EventStatus> eventStatusRepository;
+
+    @Autowired
+    private ReferenceCodeRepository<EventType> eventTypeRepository;
+
+    @Autowired
+    private ReferenceCodeRepository<MilitaryBranch> militaryBranchRepository;
+
+    @Autowired
+    private ReferenceCodeRepository<DisciplinaryAction> disciplinaryActionRepository;
+
+    @Autowired
     private TestEntityManager entityManager;
 
     @Test
@@ -76,9 +88,9 @@ public class OffenderBookingRepositoryTest {
         booking.add(
                 OffenderMilitaryRecord.builder()
                         .startDate(LocalDate.parse("2000-01-01"))
-                        .militaryBranch(new MilitaryBranch("ARM", "Army"))
+                        .militaryBranch(militaryBranchRepository.findById(MilitaryBranch.ARMY).orElseThrow())
                         .dischargeLocation("Somewhere")
-                        .disciplinaryAction(new DisciplinaryAction("CM", "Court Martial"))
+                        .disciplinaryAction(disciplinaryActionRepository.findById(DisciplinaryAction.COURT_MARTIAL).orElseThrow())
                         .build());
         repository.save(booking);
         TestTransaction.flagForCommit();
@@ -91,7 +103,7 @@ public class OffenderBookingRepositoryTest {
                 OffenderMilitaryRecord.builder()
                         .bookingAndSequence(new BookingAndSequence(booking, 1))
                         .startDate(LocalDate.parse("2000-01-01"))
-                        .militaryBranch(new MilitaryBranch("ARM", "Army"))
+                        .militaryBranch(militaryBranchRepository.findById(MilitaryBranch.ARMY).orElseThrow())
                         .dischargeLocation("Somewhere")
                         .disciplinaryAction(new DisciplinaryAction("CM", "Court Martial"))
                         .build());
@@ -110,13 +122,13 @@ public class OffenderBookingRepositoryTest {
         booking.add(
                 OffenderMilitaryRecord.builder()
                         .startDate(LocalDate.parse("2000-01-01"))
-                        .militaryBranch(new MilitaryBranch("ARM", "Army"))
+                        .militaryBranch(militaryBranchRepository.findById(MilitaryBranch.ARMY).orElseThrow())
                         .description("First record")
                         .build());
         booking.add(
                 OffenderMilitaryRecord.builder()
                         .startDate(LocalDate.parse("2000-01-01"))
-                        .militaryBranch(new MilitaryBranch("ARM", "Army"))
+                        .militaryBranch(militaryBranchRepository.findById(MilitaryBranch.ARMY).orElseThrow())
                         .description("Second record")
                         .build());
 
@@ -226,11 +238,11 @@ public class OffenderBookingRepositoryTest {
 
         return CourtEvent.builder()
                 .commentText("Comment text for court event")
-                .courtEventType(new EventType("CRT", "Court Action"))
+                .courtEventType(eventTypeRepository.findById(EventType.COURT).orElseThrow())
                 .courtLocation(agencyLocationRepository.findById("COURT1").orElseThrow())
                 .directionCode("OUT")
                 .eventDate(eventDate)
-                .eventStatus(new EventStatus("SCH", "Scheduled (Approved)"))
+                .eventStatus(eventStatusRepository.findById(EventStatus.SCHEDULED).orElseThrow())
                 .nextEventRequestFlag("X")
                 .offenderBooking(courtCase.getOffenderBooking())
                 .offenderCourtCase(courtCase)


### PR DESCRIPTION
This change mainly includes support for retrieval of reference codes (and associated refactoring) so it can be used during the creation of court hearings.