### PR TITLE
DT-609 stub jwk server

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,6 +45,19 @@ gradlew bootRun
 ./gradlew bootRun --args='--spring.profiles.active=nomis-hsqldb'
 ```
 
+#### Authenticating with JWT when running locally
+
+Since moving to Spring Security 5 the following applies when running locally without an Auth server:
+
+* Any token issued by a local Auth server will continue to be valid
+* **But** the local Auth server's `server.port` must be the same as in the property `spring.security.oauth.resource.jwt.issuer-uri` (default is `9090`)
+
+*Why?*
+
+Since moving to Spring Security 5 the JWT verification public key is now served by Auth rather than hardcoded in `application.properties`. To allow elite2 to run locally without the Auth server, class `StubJwkServer` stubs the JWK Set endpoint in the `dev` profile. In this way we can continue to validate any JWTs issued by the local Auth server.
+
+However, we also check that the issuer of the JWT matches the issuer configured in property `spring.security.oauth.resource.jwt.issuer-uri`. Therefore the Auth server issuing the JWT must be running on the same port for it to match.
+
 ### Coding Standards
 There are a few different styles in this project due to historical reasons and the accumulation of technical debt.
 

--- a/README.MD
+++ b/README.MD
@@ -47,16 +47,9 @@ gradlew bootRun
 
 #### Authenticating with JWT when running locally
 
-Since moving to Spring Security 5 the following applies when running locally without an Auth server:
+When running locally with the profile `dev` any JWT generated from a local Auth server will be valid.  This works by spinning up a Mock JWK Set server in `StubJwkServer` which provides the public key to verify the JWT signature.
 
-* Any token issued by a local Auth server will continue to be valid
-* **But** the local Auth server's `server.port` must be the same as in the property `spring.security.oauth.resource.jwt.issuer-uri` (default is `9090`)
-
-*Why?*
-
-Since moving to Spring Security 5 the JWT verification public key is now served by Auth rather than hardcoded in `application.properties`. To allow elite2 to run locally without the Auth server, class `StubJwkServer` stubs the JWK Set endpoint in the `dev` profile. In this way we can continue to validate any JWTs issued by the local Auth server.
-
-However, we also check that the issuer of the JWT matches the issuer configured in property `spring.security.oauth.resource.jwt.issuer-uri`. Therefore the Auth server issuing the JWT must be running on the same port for it to match.
+If you start this app locally without the profile `dev` then you must also spin up an Auth server and make sure that `spring.security.oauth.resource.jwt.jwk-set-uri` points to the local Auth server (e.g. http://localhost:9090/auth/.well-known/jwks.json).
 
 ### Coding Standards
 There are a few different styles in this project due to historical reasons and the accumulation of technical debt.

--- a/src/main/java/net/syscon/elite/api/support/StubJwkServer.java
+++ b/src/main/java/net/syscon/elite/api/support/StubJwkServer.java
@@ -1,0 +1,38 @@
+package net.syscon.elite.api.support;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping(value = "/auth/.well-known", produces = MediaType.APPLICATION_JSON_VALUE)
+@Profile("dev")
+public class StubJwkServer {
+
+    @GetMapping("/jwks.json")
+    public ResponseEntity<String> getJwkSet() {
+        return new ResponseEntity<>(jwks(), OK);
+    }
+
+    private String jwks() {
+        return "{\n" +
+                "  \"keys\": [\n" +
+                "    {\n" +
+                "      \"kty\": \"RSA\",\n" +
+                "      \"e\": \"AQAB\",\n" +
+                "      \"use\": \"sig\",\n" +
+                "      \"kid\": \"dps-client-key\",\n" +
+                "      \"alg\": \"RS256\",\n" +
+                "      \"n\": \"sOPAtsQADdbRu_EH6LP5BM1_mF40VDBn12hJSXPPd5WYK0HLY20VM7AxxR9mnYCF6So1Wt7fGNqUx_WyemBpIJNrs_7Dzwg3uwiQuNh4zKR-EGxWbLwi3yw7lXPUzxUyC5xt88e_7vO-lz1oCnizjh4mxNAms6ZYF7qfnhJE9WvWPwLLkojkZu1JdusLaVowN7GTGNpME8dzeJkam0gp4oxHQGhMN87K6jqX3cEwO6Dvhemg8whs96nzQl8n2LFvAK2up9Prr9Gi2LFgTt7KqXA06kC4Kgw2IR1eFgzcBlTOEwmzjre65HoNaJBr9uNZzV5sILPMczzhQj_fMhz3_Q\"\n" +
+                "    }" +
+                "  ]\n" +
+                "}\n";
+    }
+
+
+}

--- a/src/main/java/net/syscon/elite/api/support/StubJwkServer.java
+++ b/src/main/java/net/syscon/elite/api/support/StubJwkServer.java
@@ -34,5 +34,4 @@ public class StubJwkServer {
                 "}\n";
     }
 
-
 }

--- a/src/main/java/net/syscon/elite/web/config/ResourceServerConfiguration.java
+++ b/src/main/java/net/syscon/elite/web/config/ResourceServerConfiguration.java
@@ -32,7 +32,7 @@ public class ResourceServerConfiguration extends WebSecurityConfigurerAdapter {
                         "/health", "/info", "/ping", "/health/ping", "/h2-console/**",
                         "/v2/api-docs", "/api/swagger.json",
                         "/swagger-ui.html", "/swagger-resources", "/swagger-resources/configuration/ui",
-                        "/swagger-resources/configuration/security").permitAll()
+                        "/swagger-resources/configuration/security", "/auth/.well-known/jwks.json").permitAll()
                     .anyRequest().authenticated()
                 ).oauth2ResourceServer()
                     .jwt().jwtAuthenticationConverter(new AuthAwareAuthenticationConverter());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,4 +3,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://localhost:${server.port}/auth/.well-known/jwks.json
+          jwk-set-uri: http://localhost:8080/auth/.well-known/jwks.json

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost:${server.port}/auth/.well-known/jwks.json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${oauth.endpoint.url}/issuer
-          jwk-set-uri: ${oauth.endpoint.url}/.well-known/jwks.json
-
-oauth.endpoint.url: http://localhost:9090/auth
+          jwk-set-uri: http://localhost:9090/auth/.well-known/jwks.json
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
           issuer-uri: ${oauth.endpoint.url}/issuer
           jwk-set-uri: ${oauth.endpoint.url}/.well-known/jwks.json
 
-oauth.endpoint.url: http://localhost:8080/auth
+oauth.endpoint.url: http://localhost:9090/auth
 
 logging:
   level:

--- a/src/test/java/net/syscon/elite/util/JwtAuthenticationHelper.java
+++ b/src/test/java/net/syscon/elite/util/JwtAuthenticationHelper.java
@@ -53,7 +53,6 @@ public class JwtAuthenticationHelper {
                 .addClaims(claims)
                 .setExpiration(new Date(System.currentTimeMillis() + parameters.getExpiryTime().toMillis()))
                 .signWith(SignatureAlgorithm.RS256, keyPair.getPrivate())
-                .setIssuer("http://localhost:8080/auth/issuer")
                 .setHeaderParam("typ", "JWT")
                 .setHeaderParam("kid", "dps-client-key")
                 .compact();


### PR DESCRIPTION
The goal of this change is to allow for Elite2 to be started locally without any dependency on the Auth server.
In order to achieve this the property `spring.security.oauth2.resourceserver.jwt.issuer-uri` is not set locally in order to turn off JWT issuer verification. JWT issuer verification proved to be problematic due to conflicting requirements when running locally / running integration tests.  Issuer verification is turned on in all real environments (see https://github.com/ministryofjustice/nomis-api-terraform-azure/pull/218).