### PR TITLE
DT-370 Remove JWT issuer verification

### DIFF
--- a/src/main/resources/application-nomis.yml
+++ b/src/main/resources/application-nomis.yml
@@ -32,5 +32,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${oauth.endpoint.url}/issuer
           jwk-set-uri: ${oauth.endpoint.url}/.well-known/jwks.json


### PR DESCRIPTION
Spring Security only applies the JWT issue validation if the config
property for issuer URI exists.  We want to turn it off as we have
multiple URIs for the Auth server but a multiple issuer scenario is
not supported.