### PR TITLE
DT-609 remote jwk set

### DIFF
--- a/src/main/java/net/syscon/elite/web/config/JwkClient.java
+++ b/src/main/java/net/syscon/elite/web/config/JwkClient.java
@@ -40,8 +40,7 @@ public class JwkClient implements PublicKeySupplier {
     public PublicKey getPublicKeyForKeyId(final String keyId) {
         final var jwkSelector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
         final var jwk = getJwk(jwkSelector);
-        return jwk.map(this::toPublicKey)
-                .map(Optional::get)
+        return jwk.flatMap(this::toPublicKey)
                 .orElseGet(null);
     }
 
@@ -54,11 +53,11 @@ public class JwkClient implements PublicKeySupplier {
         }
     }
 
-    private Optional<PublicKey> toPublicKey(final JWK jwk) {
+    public Optional<PublicKey> toPublicKey(final JWK jwk) {
         try {
             return Optional.of(((RSAKey) jwk).toPublicKey());
         } catch (JOSEException e) {
-            log.error(format("Failed to retrieve public key from JWK %s due to exception", jwk), e);
+            log.error("Failed to retrieve public key from JWK {} due to exception", jwk, e);
         }
         return Optional.empty();
     }

--- a/src/test/java/net/syscon/elite/web/config/ClientTrackingTelemetryModuleTest_JwkClient.java
+++ b/src/test/java/net/syscon/elite/web/config/ClientTrackingTelemetryModuleTest_JwkClient.java
@@ -1,0 +1,119 @@
+package net.syscon.elite.web.config;
+
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
+import net.syscon.elite.util.JwtAuthenticationHelper;
+import net.syscon.elite.util.JwtParameters;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Duration;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+
+@RunWith(SpringRunner.class)
+@Import({JwtAuthenticationHelper.class, ClientTrackingTelemetryModule.class, JwkClient.class})
+@ContextConfiguration(initializers = {ConfigFileApplicationContextInitializer.class})
+@ActiveProfiles({"test", "test-jwk"})
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+public class ClientTrackingTelemetryModuleTest_JwkClient {
+
+    @Autowired
+    private ClientTrackingTelemetryModule clientTrackingTelemetryModule;
+
+    @Autowired
+    private JwtAuthenticationHelper jwtAuthenticationHelper;
+
+    @Rule
+    public JwkMockServer jwkServer = new JwkMockServer(9090);
+
+    @Before
+    public void setup() {
+        ThreadContext.setRequestTelemetryContext(new RequestTelemetryContext(1L));
+        jwkServer.stubJwkServer();
+        jwkServer.start();
+    }
+
+    @After
+    public void tearDown() {
+        ThreadContext.remove();
+        jwkServer.stop();
+        jwkServer.resetAll();
+    }
+
+    @Test
+    public void shouldAddClientIdAndUserNameToInsightTelemetry() {
+
+        final var token = createJwt("bob", List.of(), 1L);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        clientTrackingTelemetryModule.onBeginRequest(req, res);
+
+        final var insightTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry().getProperties();
+
+        assertThat(insightTelemetry).hasSize(3);
+        assertThat(insightTelemetry.get("username")).isEqualTo("bob");
+        assertThat(insightTelemetry.get("clientId")).isEqualTo("elite2apiclient");
+        assertThat(insightTelemetry.get("clientIpAddress")).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    public void shouldNotAddClientIdAndUserNameToInsightTelemetryAsTokenExpired() {
+
+        final var token = createJwt("Fred", List.of(), -1L);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        clientTrackingTelemetryModule.onBeginRequest(req, res);
+
+        final var insightTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry().getProperties();
+
+        assertThat(insightTelemetry).isEmpty();
+    }
+
+    @Test
+    public void shouldRetrieveJwkSetFromServer_onlyOnce() {
+
+        final var token = createJwt("bob", List.of(), 1L);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        clientTrackingTelemetryModule.onBeginRequest(req, res);
+        clientTrackingTelemetryModule.onBeginRequest(req, res);
+
+        jwkServer.verify(1, getRequestedFor(urlEqualTo("/auth/.well-known/jwks.json")));
+    }
+
+    private String createJwt(final String user, final List<String> roles, Long duration) {
+        return jwtAuthenticationHelper.createJwt(JwtParameters.builder()
+                .username(user)
+                .roles(roles)
+                .scope(List.of("read", "write"))
+                .expiryTime(Duration.ofDays(duration))
+                .build());
+    }
+
+}

--- a/src/test/java/net/syscon/elite/web/config/ClientTrackingTelemetryModuleTest_JwkClient.java
+++ b/src/test/java/net/syscon/elite/web/config/ClientTrackingTelemetryModuleTest_JwkClient.java
@@ -58,7 +58,7 @@ public class ClientTrackingTelemetryModuleTest_JwkClient {
     }
 
     @Test
-    public void shouldAddClientIdAndUserNameToInsightTelemetry() {
+    public void shouldAddClientIdAndUserNameAndClientIpToInsightTelemetry() {
 
         final var token = createJwt("bob", List.of(), 1L);
 
@@ -77,7 +77,7 @@ public class ClientTrackingTelemetryModuleTest_JwkClient {
     }
 
     @Test
-    public void shouldNotAddClientIdAndUserNameToInsightTelemetryAsTokenExpired() {
+    public void shouldNotAddUserDetailsToInsightTelemetryAsTokenExpired() {
 
         final var token = createJwt("Fred", List.of(), -1L);
 

--- a/src/test/java/net/syscon/elite/web/config/JwkMockServer.java
+++ b/src/test/java/net/syscon/elite/web/config/JwkMockServer.java
@@ -1,0 +1,40 @@
+package net.syscon.elite.web.config;
+
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+class JwkMockServer extends WireMockRule {
+
+    JwkMockServer(int port) {
+        super(port);
+    }
+
+    void stubJwkServer() {
+        stubFor(
+                get(urlEqualTo("/auth/.well-known/jwks.json"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeaders(new com.github.tomakehurst.wiremock.http.HttpHeaders(new HttpHeader("Content-Type", "application/json")))
+                                        .withStatus(200)
+                                        .withBody(jwkSet()))
+        );
+    }
+
+    private String jwkSet() {
+        return "{\n" +
+                "  \"keys\": [\n" +
+                "    {\n" +
+                "      \"kty\": \"RSA\",\n" +
+                "      \"e\": \"AQAB\",\n" +
+                "      \"use\": \"sig\",\n" +
+                "      \"kid\": \"dps-client-key\",\n" +
+                "      \"alg\": \"RS256\",\n" +
+                "      \"n\": \"sOPAtsQADdbRu_EH6LP5BM1_mF40VDBn12hJSXPPd5WYK0HLY20VM7AxxR9mnYCF6So1Wt7fGNqUx_WyemBpIJNrs_7Dzwg3uwiQuNh4zKR-EGxWbLwi3yw7lXPUzxUyC5xt88e_7vO-lz1oCnizjh4mxNAms6ZYF7qfnhJE9WvWPwLLkojkZu1JdusLaVowN7GTGNpME8dzeJkam0gp4oxHQGhMN87K6jqX3cEwO6Dvhemg8whs96nzQl8n2LFvAK2up9Prr9Gi2LFgTt7KqXA06kC4Kgw2IR1eFgzcBlTOEwmzjre65HoNaJBr9uNZzV5sILPMczzhQj_fMhz3_Q\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+    }
+
+}

--- a/src/test/resources/application-test-jwk.yml
+++ b/src/test/resources/application-test-jwk.yml
@@ -1,0 +1,1 @@
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri: http://localhost:9090/auth/.well-known/jwks.json


### PR DESCRIPTION
Use the existing RemoteJWKSet to retrieve the JWK set as this supports caching out of the box.  And is standard.