### PR TITLE
Nn 2493 location casing update

### DIFF
--- a/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
+++ b/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
@@ -69,6 +69,7 @@ public class LocationProcessor {
      * @throws {@code NullPointerException} if no location provided for processing.
      */
     public static List<Location> processLocations(final List<Location> locations, final boolean preferUserDescription) {
+        System.out.println(locations);
         Objects.requireNonNull(locations);
 
         return locations.stream().map(loc -> processLocation(loc, preferUserDescription)).collect(Collectors.toList());
@@ -139,6 +140,10 @@ public class LocationProcessor {
      *
      */
     public static String formatLocation(final String locationDescription) {
+        // Handle the possibility of the userDescription being empty
+        if (locationDescription == null) {
+            return null;
+        }
         var description = WordUtils.capitalizeFully(locationDescription);
         // Using word boundaries to find the right string ensures we catch the strings
         // wherever they appear in the description, while also avoiding replacing

--- a/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
+++ b/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
@@ -69,7 +69,6 @@ public class LocationProcessor {
      * @throws {@code NullPointerException} if no location provided for processing.
      */
     public static List<Location> processLocations(final List<Location> locations, final boolean preferUserDescription) {
-        System.out.println(locations);
         Objects.requireNonNull(locations);
 
         return locations.stream().map(loc -> processLocation(loc, preferUserDescription)).collect(Collectors.toList());

--- a/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
+++ b/src/main/java/net/syscon/elite/service/support/LocationProcessor.java
@@ -155,12 +155,12 @@ public class LocationProcessor {
         // e.g. HMP Moorland VCC Room 1
         // By using the string buffer and the appendReplacement method
         // we ensure that all the matching groups are replaced accordingly
-        StringBuffer stringBuffer = new StringBuffer();
+        StringBuilder stringBuilder = new StringBuilder();
         while (matcher.find()) {
             var matched = matcher.group(1);
-            matcher.appendReplacement(stringBuffer, matched.toUpperCase());
+            matcher.appendReplacement(stringBuilder, matched.toUpperCase());
         }
-        matcher.appendTail(stringBuffer);
-        return stringBuffer.toString();
+        matcher.appendTail(stringBuilder);
+        return stringBuilder.toString();
     }
 }

--- a/src/test/java/net/syscon/elite/api/resource/impl/OffenderMovementsResourceImplIntTest.java
+++ b/src/test/java/net/syscon/elite/api/resource/impl/OffenderMovementsResourceImplIntTest.java
@@ -132,4 +132,28 @@ public class OffenderMovementsResourceImplIntTest extends ResourceTest {
                         .developerMessage("Resource with id [8888888] not found.")
                         .build());
     }
+
+    @Test
+    public void schedule_court_hearing_fails_when_unauthorised() {
+        final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.RENEGADE_USER);
+
+        final var request = createHttpEntity(token, Map.of(
+                "courtCaseId", -1,
+                "fromPrisonLocation", "LEI",
+                "toCourtLocation", "COURT1",
+                "courtHearingDateTime", "2030-03-11T14:00:00.000Z"
+        ));
+
+        final var response = testRestTemplate.exchange(
+                "/api/bookings/-1/prison-to-court-hearings",
+                HttpMethod.POST,
+                request,
+                ErrorResponse.class);
+
+        assertThat(response.getBody()).isEqualTo(
+                ErrorResponse.builder()
+                        .status(403)
+                        .userMessage("Access is denied")
+                        .build());
+    }
 }

--- a/src/test/java/net/syscon/elite/service/support/LocationProcessorTest.java
+++ b/src/test/java/net/syscon/elite/service/support/LocationProcessorTest.java
@@ -151,6 +151,14 @@ public class LocationProcessorTest {
         assertThat(processedLocations.get(1).getUserDescription()).isNull();
     }
 
+    @Test
+    public void formatLocationAbbreviations() {
+        // Assert that all abbreviations are unchanged, even when there a multiple ones in a string
+        final var abbreviationsString = String.join(", ", LocationProcessor.ABBREVIATIONS);
+        assertThat(LocationProcessor.formatLocation(abbreviationsString)).isEqualTo(abbreviationsString);
+
+    }
+
     private Location buildTestLocation(final String userDescription) {
         return Location.builder()
                 .agencyId(TEST_AGENCY_ID)


### PR DESCRIPTION
Currently the location formatter will titlecase most abbreviations, resulting in rooms showing up as "Vcc Room 1", for example. This change introduces a list of abbreviations to be excluded from titlecasing and adds a test for the specific method.