### PR TITLE
DT-651 small improvement to tighten validation of request for court hearing retrieval

### DIFF
--- a/src/main/java/net/syscon/elite/service/BadRequestException.java
+++ b/src/main/java/net/syscon/elite/service/BadRequestException.java
@@ -1,0 +1,7 @@
+package net.syscon.elite.service;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/syscon/elite/service/CourtHearingsService.java
+++ b/src/main/java/net/syscon/elite/service/CourtHearingsService.java
@@ -97,6 +97,8 @@ public class CourtHearingsService {
      */
     @VerifyBookingAccess
     public CourtHearings getCourtHearingsFor(final Long bookingId, final LocalDate fromDate, final LocalDate toDate) {
+        checkFromAndToDatesAreValid(fromDate, toDate);
+
         final var courtHearingsBuilder = CourtHearings.builder();
 
         courtEventRepository.findAll(CourtEventFilter.builder()
@@ -116,6 +118,16 @@ public class CourtHearingsService {
                 );
 
         return courtHearingsBuilder.build();
+    }
+
+    private void checkFromAndToDatesAreValid(final LocalDate from, final LocalDate to) {
+        if (from == null || to == null) {
+            return;
+        }
+
+        if (to.isBefore(from)) {
+            throw new BadRequestException("Invalid date range: toDate is before fromDate.");
+        }
     }
 
     private void checkHearingIsInFuture(final LocalDateTime courtHearingDateTime) {

--- a/src/main/java/net/syscon/elite/web/handler/ControllerAdvice.java
+++ b/src/main/java/net/syscon/elite/web/handler/ControllerAdvice.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.syscon.elite.api.model.ErrorResponse;
 import net.syscon.elite.service.EntityNotFoundException;
 import net.syscon.elite.service.NoContentException;
+import net.syscon.elite.service.BadRequestException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -235,4 +236,16 @@ public class ControllerAdvice {
                         .build());
     }
 
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleServiceException(final BadRequestException e) {
+        log.debug("Bad Request (400) returned", e);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse
+                        .builder()
+                        .userMessage(e.getMessage())
+                        .status(HttpStatus.BAD_REQUEST.value())
+                        .developerMessage(e.getMessage())
+                        .build());
+    }
 }

--- a/src/test/java/net/syscon/elite/api/resource/impl/OffenderMovementsResourceImplIntTest.java
+++ b/src/test/java/net/syscon/elite/api/resource/impl/OffenderMovementsResourceImplIntTest.java
@@ -233,4 +233,22 @@ public class OffenderMovementsResourceImplIntTest extends ResourceTest {
                 .developerMessage("Resource with id [666] not found.")
                 .build());
     }
+
+    @Test
+    public void get_court_hearings_for_booking_fails_on_invalid_date_range() {
+        final var token = authTokenHelper.getToken(AuthTokenHelper.AuthToken.NORMAL_USER);
+
+        final var request = createHttpEntity(token, null);
+
+        final var response = testRestTemplate.exchange(
+                "/api/bookings/-1/court-hearings?fromDate=2020-03-23&toDate=2020-03-22",
+                HttpMethod.GET,
+                request,ErrorResponse.class);
+
+        assertThat(response.getBody()).isEqualTo(ErrorResponse.builder()
+                .status(400)
+                .userMessage("Invalid date range: toDate is before fromDate.")
+                .developerMessage("Invalid date range: toDate is before fromDate.")
+                .build());
+    }
 }

--- a/src/test/java/net/syscon/elite/service/CourtHearingsServiceTest.java
+++ b/src/test/java/net/syscon/elite/service/CourtHearingsServiceTest.java
@@ -31,8 +31,7 @@ import java.util.Optional;
 
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -417,6 +416,21 @@ public class CourtHearingsServiceTest {
                 );
     }
 
+    @Test
+    void getCourtHearings_throws_service_exception_for_invalid_dates() {
+        assertThatThrownBy(() -> courtHearingsService.getCourtHearingsFor(-1L, LocalDate.of(2020, 3, 23), LocalDate.of(2020, 3, 22)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Invalid date range: toDate is before fromDate.");
+    }
+
+    @Test
+    void getCourtHearings_does_not_throw_service_exception_for_valid_dates() {
+        assertThatCode(() -> courtHearingsService.getCourtHearingsFor(-1L, LocalDate.of(2020, 3, 22), LocalDate.of(2020, 3, 23)))
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> courtHearingsService.getCourtHearingsFor(-1L, LocalDate.of(2020, 3, 22), LocalDate.of(2020, 3, 22)))
+                .doesNotThrowAnyException();
+    }
 
     private void givenValidBookingWithOneOrMoreCourtHearings(final Long bookingId, final CourtEvent... events) {
         when(courtEventRepository.findAll(CourtEventFilter.builder().bookingId(bookingId).build())).thenReturn(asList(events));


### PR DESCRIPTION
Change to return bad request if the supplied date range for court hearings is incorrect i.e. to before start.