### PR TITLE
DT-635 Add tests for Oracle Connection Aspect

### DIFF
--- a/src/test/java/net/syscon/elite/aop/connectionproxy/OracleConnectionAspectTest.java
+++ b/src/test/java/net/syscon/elite/aop/connectionproxy/OracleConnectionAspectTest.java
@@ -1,0 +1,81 @@
+package net.syscon.elite.aop.connectionproxy;
+
+import net.syscon.elite.security.AuthSource;
+import net.syscon.elite.security.AuthenticationFacade;
+import oracle.jdbc.driver.OracleConnection;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class OracleConnectionAspectTest {
+
+    private final AuthenticationFacade authenticationFacade = mock(AuthenticationFacade.class);
+    private final RoleConfigurer roleConfigurer = mock(RoleConfigurer.class);
+    private final String defaultSchema = "some default schema";
+    private final Connection pooledConnection = mock(Connection.class);
+    private final PreparedStatement pooledPreparedStatement = mock(PreparedStatement.class);
+    private final OracleConnection proxyConnection = mock(OracleConnection.class);
+    private final PreparedStatement proxyPreparedStatement = mock(PreparedStatement.class);
+
+    private final OracleConnectionAspect connectionAspect = new OracleConnectionAspect(authenticationFacade, roleConfigurer, defaultSchema);
+
+    @Test
+    public void openProxySessionIfIdentifiedAuthentication_nomisUser_opensProxyConnection() throws SQLException {
+        configureMocks(AuthSource.NOMIS);
+
+        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+        ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
+        verify(proxyConnection).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), propertiesCaptor.capture());
+        assertThat(propertiesCaptor.getValue().get((OracleConnection.PROXY_USER_NAME))).isEqualTo("some user name");
+    }
+
+    @Test
+    public void openProxySessionIfIdentifiedAuthentication_nomisUser_setSchemaAndContext() throws SQLException {
+        configureMocks(AuthSource.NOMIS);
+
+        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(pooledConnection, times(2)).prepareStatement(sqlCaptor.capture());
+        assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+        assertThat(sqlCaptor.getAllValues().get(1)).contains("nomis_context.set_context");
+    }
+
+    @Test
+    public void openProxySessionIfIdentifiedAuthentication_notANomisUser_doesntOpenProxyConnection() throws SQLException {
+        configureMocks(AuthSource.NONE);
+
+        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+        verify(proxyConnection, never()).openProxySession(eq(OracleConnection.PROXYTYPE_USER_NAME), any(Properties.class));
+    }
+
+    @Test
+    public void openProxySessionIfIdentifiedAuthentication_notANomisUser_setSchemaButNotContext() throws SQLException {
+        configureMocks(AuthSource.NONE);
+
+        connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(pooledConnection, times(1)).prepareStatement(sqlCaptor.capture());
+        assertThat(sqlCaptor.getAllValues().get(0)).contains("ALTER SESSION SET CURRENT_SCHEMA");
+    }
+
+    private void configureMocks(AuthSource authSource) throws SQLException {
+        when(authenticationFacade.getProxyUserAuthenticationSource()).thenReturn(authSource);
+        when(authenticationFacade.getCurrentUsername()).thenReturn("some user name");
+        when(pooledConnection.unwrap(Connection.class)).thenReturn(proxyConnection);
+        when(proxyConnection.prepareStatement(anyString())).thenReturn(proxyPreparedStatement);
+        when(pooledConnection.prepareStatement(anyString())).thenReturn(pooledPreparedStatement);
+
+    }
+
+}

--- a/src/test/java/net/syscon/elite/aop/connectionproxy/OracleConnectionAspectTest.java
+++ b/src/test/java/net/syscon/elite/aop/connectionproxy/OracleConnectionAspectTest.java
@@ -3,7 +3,7 @@ package net.syscon.elite.aop.connectionproxy;
 import net.syscon.elite.security.AuthSource;
 import net.syscon.elite.security.AuthenticationFacade;
 import oracle.jdbc.driver.OracleConnection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.sql.Connection;
@@ -14,7 +14,7 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-public class OracleConnectionAspectTest {
+class OracleConnectionAspectTest {
 
     private final AuthenticationFacade authenticationFacade = mock(AuthenticationFacade.class);
     private final RoleConfigurer roleConfigurer = mock(RoleConfigurer.class);
@@ -27,7 +27,7 @@ public class OracleConnectionAspectTest {
     private final OracleConnectionAspect connectionAspect = new OracleConnectionAspect(authenticationFacade, roleConfigurer, defaultSchema);
 
     @Test
-    public void openProxySessionIfIdentifiedAuthentication_nomisUser_opensProxyConnection() throws SQLException {
+    void openProxySessionIfIdentifiedAuthentication_nomisUser_opensProxyConnection() throws SQLException {
         configureMocks(AuthSource.NOMIS);
 
         connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
@@ -38,7 +38,7 @@ public class OracleConnectionAspectTest {
     }
 
     @Test
-    public void openProxySessionIfIdentifiedAuthentication_nomisUser_setSchemaAndContext() throws SQLException {
+    void openProxySessionIfIdentifiedAuthentication_nomisUser_setSchemaAndContext() throws SQLException {
         configureMocks(AuthSource.NOMIS);
 
         connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
@@ -50,7 +50,7 @@ public class OracleConnectionAspectTest {
     }
 
     @Test
-    public void openProxySessionIfIdentifiedAuthentication_notANomisUser_doesntOpenProxyConnection() throws SQLException {
+    void openProxySessionIfIdentifiedAuthentication_notANomisUser_doesntOpenProxyConnection() throws SQLException {
         configureMocks(AuthSource.NONE);
 
         connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);
@@ -59,7 +59,7 @@ public class OracleConnectionAspectTest {
     }
 
     @Test
-    public void openProxySessionIfIdentifiedAuthentication_notANomisUser_setSchemaButNotContext() throws SQLException {
+    void openProxySessionIfIdentifiedAuthentication_notANomisUser_setSchemaButNotContext() throws SQLException {
         configureMocks(AuthSource.NONE);
 
         connectionAspect.openProxySessionIfIdentifiedAuthentication(pooledConnection);


### PR DESCRIPTION
Add tests to illustrate the different outcomes for a Nomis and non-Nomis connection.