### PR TITLE
NN-2447: Allow updating attendance for bookings outside of caseload

### DIFF
--- a/src/main/java/net/syscon/elite/service/BookingService.java
+++ b/src/main/java/net/syscon/elite/service/BookingService.java
@@ -266,7 +266,6 @@ public class BookingService {
     }
 
     private void updateAttendance(final Long activityId, final UpdateAttendance updateAttendance, final OffenderSummary offenderSummary) {
-        verifyBookingAccess(offenderSummary.getBookingId());
         validateActivity(activityId);
 
         // Copy flags from the PAYABLE_ATTENDANCE_OUTCOME reference table

--- a/src/test/java/net/syscon/elite/service/BookingServiceTest.java
+++ b/src/test/java/net/syscon/elite/service/BookingServiceTest.java
@@ -189,9 +189,6 @@ public class BookingServiceTest {
                 .thenReturn(Optional.of(OffenderSummary.builder().bookingId(2L).build()))
                 .thenReturn(Optional.of(OffenderSummary.builder().bookingId(3L).build()));
 
-        when(agencyService.getAgencyIds()).thenReturn(Set.of("MDI"));
-        when(bookingRepository.verifyBookingAccess(anyLong(), anySet())).thenReturn(true);
-
         when(bookingRepository.getAttendanceEventDate(anyLong())).thenReturn(LocalDate.now());
         when(bookingRepository.getPayableAttendanceOutcome(anyString(), anyString()))
                 .thenReturn(PayableAttendanceOutcomeDto


### PR DESCRIPTION
In whereabouts, we show historical records for offenders who may have transferred out of the establishment. Users still need to be able to pay them for outstanding activities even if the offender is no longer in that caseload. This removes the check limiting attendance updates to bookings currently in the user's caseload.