### PR TITLE
DT-704: Remove unused offender no alerts endpoint

### DIFF
--- a/src/main/java/net/syscon/elite/api/resource/BookingResource.java
+++ b/src/main/java/net/syscon/elite/api/resource/BookingResource.java
@@ -163,21 +163,6 @@ public interface BookingResource {
                                                   @ApiParam(value = "Comma separated list of one or more of the following fields - <b>alertType, alertCode, dateCreated, dateExpires</b>") @RequestHeader(value = "Sort-Fields", required = false) String sortFields,
                                                   @ApiParam(value = "Sort order (ASC or DESC) - defaults to ASC.", defaultValue = "ASC") @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) Order sortOrder);
 
-    @GetMapping("/offenderNo/{offenderNo}/alerts")
-    @ApiOperation(value = "Offender alerts offenderNo.", notes = "Offender alerts by offenderNo.", nickname = "getOffenderAlertsByOffenderNo")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Alert.class, responseContainer = "List"),
-            @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
-    ResponseEntity<List<Alert>> getOffenderAlertsByOffenderNo(@ApiParam(value = "The offender no of the offender", required = true) @PathVariable("offenderNo") String offenderNo,
-                                                              @ApiParam(value = "Search parameters with the format [connector]:&lt;fieldName&gt;:&lt;operator&gt;:&lt;value&gt;:[format],... <p>Connector operators - and, or <p>Supported Operators - eq, neq, gt, gteq, lt, lteq, like, in</p> <p>Supported Fields - alertType, alertCode, dateCreated, dateExpires</p> ", required = false) @RequestParam(value = "query", required = false) String query,
-                                                              @ApiParam(value = "Requested offset of first record in returned collection of alert records.", defaultValue = "0") @RequestHeader(value = "Page-Offset", defaultValue = "0", required = false) Long pageOffset,
-                                                              @ApiParam(value = "Requested limit to number of alert records returned.", defaultValue = "10") @RequestHeader(value = "Page-Limit", defaultValue = "10", required = false) Long pageLimit,
-                                                              @ApiParam(value = "Comma separated list of one or more of the following fields - <b>alertType, alertCode, dateCreated, dateExpires</b>") @RequestHeader(value = "Sort-Fields", required = false) String sortFields,
-                                                              @ApiParam(value = "Sort order (ASC or DESC) - defaults to ASC.", defaultValue = "ASC") @RequestHeader(value = "Sort-Order", defaultValue = "ASC", required = false) Order sortOrder);
-
-
     @GetMapping("/{bookingId}/alerts/{alertId}")
     @ApiOperation(value = "Offender alert detail.", notes = "Offender alert detail.", nickname = "getOffenderAlert")
     @ApiResponses(value = {

--- a/src/main/java/net/syscon/elite/api/resource/impl/BookingResourceImpl.java
+++ b/src/main/java/net/syscon/elite/api/resource/impl/BookingResourceImpl.java
@@ -1,7 +1,52 @@
 package net.syscon.elite.api.resource.impl;
 
 import lombok.AllArgsConstructor;
-import net.syscon.elite.api.model.*;
+import net.syscon.elite.api.model.Account;
+import net.syscon.elite.api.model.Alert;
+import net.syscon.elite.api.model.AlertChanges;
+import net.syscon.elite.api.model.AlertCreated;
+import net.syscon.elite.api.model.Alias;
+import net.syscon.elite.api.model.Assessment;
+import net.syscon.elite.api.model.CaseNote;
+import net.syscon.elite.api.model.CaseNoteCount;
+import net.syscon.elite.api.model.Contact;
+import net.syscon.elite.api.model.ContactDetail;
+import net.syscon.elite.api.model.CourtCase;
+import net.syscon.elite.api.model.CreateAlert;
+import net.syscon.elite.api.model.ErrorResponse;
+import net.syscon.elite.api.model.IepLevelAndComment;
+import net.syscon.elite.api.model.ImageDetail;
+import net.syscon.elite.api.model.IncidentCase;
+import net.syscon.elite.api.model.InmateBasicDetails;
+import net.syscon.elite.api.model.InmateDetail;
+import net.syscon.elite.api.model.Keyworker;
+import net.syscon.elite.api.model.MilitaryRecords;
+import net.syscon.elite.api.model.Movement;
+import net.syscon.elite.api.model.NewAppointment;
+import net.syscon.elite.api.model.NewBooking;
+import net.syscon.elite.api.model.NewCaseNote;
+import net.syscon.elite.api.model.Offence;
+import net.syscon.elite.api.model.OffenceDetail;
+import net.syscon.elite.api.model.OffenceHistoryDetail;
+import net.syscon.elite.api.model.OffenderBooking;
+import net.syscon.elite.api.model.OffenderIdentifier;
+import net.syscon.elite.api.model.OffenderRelationship;
+import net.syscon.elite.api.model.OffenderSummary;
+import net.syscon.elite.api.model.PersonalCareNeeds;
+import net.syscon.elite.api.model.PhysicalAttributes;
+import net.syscon.elite.api.model.PhysicalCharacteristic;
+import net.syscon.elite.api.model.PhysicalMark;
+import net.syscon.elite.api.model.PrivilegeSummary;
+import net.syscon.elite.api.model.ProfileInformation;
+import net.syscon.elite.api.model.ReasonableAdjustments;
+import net.syscon.elite.api.model.RecallBooking;
+import net.syscon.elite.api.model.ScheduledEvent;
+import net.syscon.elite.api.model.SentenceDetail;
+import net.syscon.elite.api.model.UpdateAttendance;
+import net.syscon.elite.api.model.UpdateAttendanceBatch;
+import net.syscon.elite.api.model.UpdateCaseNote;
+import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.adjudications.AdjudicationSummary;
 import net.syscon.elite.api.resource.BookingResource;
 import net.syscon.elite.api.support.Order;
@@ -10,7 +55,21 @@ import net.syscon.elite.core.HasWriteScope;
 import net.syscon.elite.core.ProxyUser;
 import net.syscon.elite.security.AuthenticationFacade;
 import net.syscon.elite.security.VerifyOffenderAccess;
-import net.syscon.elite.service.*;
+import net.syscon.elite.service.AdjudicationService;
+import net.syscon.elite.service.AppointmentsService;
+import net.syscon.elite.service.BookingMaintenanceService;
+import net.syscon.elite.service.BookingService;
+import net.syscon.elite.service.CaseNoteService;
+import net.syscon.elite.service.ContactService;
+import net.syscon.elite.service.EntityNotFoundException;
+import net.syscon.elite.service.FinanceService;
+import net.syscon.elite.service.IdempotentRequestService;
+import net.syscon.elite.service.ImageService;
+import net.syscon.elite.service.IncidentService;
+import net.syscon.elite.service.InmateAlertService;
+import net.syscon.elite.service.InmateSearchCriteria;
+import net.syscon.elite.service.InmateService;
+import net.syscon.elite.service.MovementsService;
 import net.syscon.elite.service.keyworker.KeyWorkerAllocationService;
 import net.syscon.elite.service.support.WrappedErrorResponseException;
 import net.syscon.elite.web.handler.ResourceExceptionHandler;
@@ -255,13 +314,6 @@ public class BookingResourceImpl implements BookingResource {
         return ResponseEntity.ok()
                 .headers(inmateAlerts.getPaginationHeaders())
                 .body(inmateAlerts.getItems());
-    }
-
-    @Override
-    @VerifyOffenderAccess(overrideRoles = {"SYSTEM_USER", "GLOBAL_SEARCH"})
-    public ResponseEntity<List<Alert>> getOffenderAlertsByOffenderNo(final String offenderNo, final String query, final Long pageOffset, final Long pageLimit, final String sortFields, final Order sortOrder) {
-        final var bookingId = bookingService.getBookingIdByOffenderNo(offenderNo);
-        return getOffenderAlerts(bookingId, query, pageOffset, pageLimit, sortFields, sortOrder);
     }
 
     @Override

--- a/src/test/java/net/syscon/elite/executablespecification/BookingStepDefinitions.java
+++ b/src/test/java/net/syscon/elite/executablespecification/BookingStepDefinitions.java
@@ -5,7 +5,13 @@ import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import net.syscon.elite.api.model.Alert;
-import net.syscon.elite.executablespecification.steps.*;
+import net.syscon.elite.executablespecification.steps.BookingAlertSteps;
+import net.syscon.elite.executablespecification.steps.BookingAliasSteps;
+import net.syscon.elite.executablespecification.steps.BookingAssessmentSteps;
+import net.syscon.elite.executablespecification.steps.BookingDetailSteps;
+import net.syscon.elite.executablespecification.steps.BookingIEPSteps;
+import net.syscon.elite.executablespecification.steps.BookingSearchSteps;
+import net.syscon.elite.executablespecification.steps.BookingSentenceSteps;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -123,12 +129,12 @@ public class BookingStepDefinitions extends AbstractStepDefinitions {
 
     @Then("^\"([^\"]*)\" booking records are returned$")
     public void bookingRecordsAreReturned(final String expectedCount) {
-        bookingSearch.verifyResourceRecordsReturned(Long.valueOf(expectedCount));
+        bookingSearch.verifyResourceRecordsReturned(Long.parseLong(expectedCount));
     }
 
     @Then("^\"([^\"]*)\" total booking records are available$")
     public void totalBookingRecordsAreAvailable(final String expectedCount) {
-        bookingSearch.verifyTotalResourceRecordsAvailable(Long.valueOf(expectedCount));
+        bookingSearch.verifyTotalResourceRecordsAvailable(Long.parseLong(expectedCount));
     }
 
     @When("^aliases are requested for an offender booking \"([^\"]*)\"$")
@@ -138,7 +144,7 @@ public class BookingStepDefinitions extends AbstractStepDefinitions {
 
     @Then("^\"([^\"]*)\" aliases are returned$")
     public void aliasesAreReturned(final String expectedCount) {
-        bookingAlias.verifyResourceRecordsReturned(Long.valueOf(expectedCount));
+        bookingAlias.verifyResourceRecordsReturned(Long.parseLong(expectedCount));
     }
 
     @And("^alias first names match \"([^\"]*)\"$")
@@ -298,14 +304,9 @@ public class BookingStepDefinitions extends AbstractStepDefinitions {
         bookingAlerts.getAlerts(bookingId);
     }
 
-    @When("^alerts are requested for an offender booking using offender No \"([^\"]*)\"$")
-    public void alertsAreRequestedForOffenderBookingByOffenderNo(final String offenderNo) {
-        bookingAlerts.getAlertsByOffenderNo(offenderNo);
-    }
-
     @Then("^\"([^\"]*)\" alerts are returned$")
     public void numberAlertsAreReturned(final String expectedCount) {
-        bookingAlerts.verifyResourceRecordsReturned(Long.valueOf(expectedCount));
+        bookingAlerts.verifyResourceRecordsReturned(Long.parseLong(expectedCount));
     }
 
     @And("alerts codes match \"([^\"]*)\"$")
@@ -642,17 +643,17 @@ public class BookingStepDefinitions extends AbstractStepDefinitions {
     }
 
     @When("^a request is made for offender categorisation details at \"([^\"]*)\" with booking id \"([^\"]*)\", latest cat only$")
-    public void aRequestIsMadeForOffenderCategorisationDetailsAtWithBookingIdLatest(String agency, String bookingId) {
+    public void aRequestIsMadeForOffenderCategorisationDetailsAtWithBookingIdLatest(final String agency, final String bookingId) {
         bookingAssessment.getOffendersCategorisations(agency, Collections.singletonList(Long.valueOf(bookingId)), true);
     }
 
     @When("^a request is made for offender categorisation details at \"([^\"]*)\" with booking id \"([^\"]*)\", all cats$")
-    public void aRequestIsMadeForOffenderCategorisationDetailsAtWithBookingIdAll(String agency, String bookingId) {
+    public void aRequestIsMadeForOffenderCategorisationDetailsAtWithBookingIdAll(final String agency, final String bookingId) {
         bookingAssessment.getOffendersCategorisations(agency, Collections.singletonList(Long.valueOf(bookingId)), false);
     }
 
     @Then("^\"([^\"]*)\" rows of basic inmate details are returned$")
-    public void rowsOfBasicInmateDetailsAreReturned(String count) {
-        bookingDetail.verifyOffendersBasicCount(Integer.valueOf(count));
+    public void rowsOfBasicInmateDetailsAreReturned(final String count) {
+        bookingDetail.verifyOffendersBasicCount(Integer.parseInt(count));
     }
 }

--- a/src/test/java/net/syscon/elite/executablespecification/steps/BookingAlertSteps.java
+++ b/src/test/java/net/syscon/elite/executablespecification/steps/BookingAlertSteps.java
@@ -29,11 +29,6 @@ public class BookingAlertSteps extends CommonSteps {
         doListApiCall(bookingId);
     }
 
-    @Step("Retrieve alerts for offender no")
-    public void getAlertsByOffenderNo(final String offenderNo) {
-        doListApiCallForOffender(offenderNo);
-    }
-
     @Step("Retrieve alerts for offender nos")
     public void getAlerts(final String agencyId, final List<String> offenderNos) {
         doPostApiCall(agencyId, offenderNos);

--- a/src/test/resources/features/booking_alerts.feature
+++ b/src/test/resources/features/booking_alerts.feature
@@ -16,16 +16,6 @@ Feature: Booking Alerts
        | -1        | 4      | XA,HC,RSS,XTACT |
        | -2        | 2      | HA,XTACT        |
 
-  Scenario Outline: Retrieve alerts for an offender by Offender No
-    When alerts are requested for an offender booking using offender No "<offenderNo>"
-    Then "<number>" alerts are returned
-    And alerts codes match "<alert code list>"
-
-    Examples:
-      | offenderNo | number | alert code list |
-      | A1234AA    | 4      | XA,HC,RSS,XTACT |
-      | A1234AB    | 2      | HA,XTACT        |
-
   Scenario Outline: Retrieve alert for an offender booking
     When alert is requested for an offender booking "<bookingId>" and alert id "<alertId>"
     Then alert alertType is "<alertType>"


### PR DESCRIPTION
Ran
```
requests
| where cloud_RoleName == 'elite2-api'
| where name contains 'getOffenderAlertsByOffenderNo'
```
over the last two months to check it wasn't used in production (or dev).

Also ran
```
requests
| where cloud_RoleName == 'elite2-api'
| where url contains 'alerts'
| where name startswith 'GET'
| where url contains 'offenderNo'
```
for good measure too :grin: 