### PR TITLE
GDPR-120 Adding extra logging to help debug deletion script issue

### DIFF
--- a/src/main/java/net/syscon/elite/repository/impl/OffenderDeletionRepositoryImpl.java
+++ b/src/main/java/net/syscon/elite/repository/impl/OffenderDeletionRepositoryImpl.java
@@ -413,20 +413,24 @@ public class OffenderDeletionRepositoryImpl extends RepositoryBase implements Of
     }
 
     private int executeNamedSqlWithOffenderIds(final String sql, final Set<String> ids) {
+        log.debug("Executing deletion SQL: {}, with ids: {}", sql, ids);
         return jdbcTemplate.update(getQuery(sql), createParams("offenderIds", ids));
     }
 
     private void executeNamedSqlWithBookingIds(final String sql, final Set<String> ids) {
+        log.debug("Executing deletion SQL: {}, with ids: {}", sql, ids);
         jdbcTemplate.update(getQuery(sql), createParams("bookIds", ids));
     }
 
     private int executeNamedSqlWithOffenderIdsAndBookingIds(final String sql,
                                                             final Set<String> offenderIds,
                                                             final Set<String> bookIds) {
+        log.debug("Executing deletion SQL: {}, with offender ids: {} and bookIds: {}", sql, offenderIds, bookIds);
         return jdbcTemplate.update(getQuery(sql), createParams("offenderIds", offenderIds, "bookIds", bookIds.isEmpty() ? null : bookIds));
     }
 
     private void executeNamedSqlWithIncidentCaseIds(final String sql, final Set<String> ids) {
+        log.debug("Executing deletion SQL: {}, with incident case ids: {}", sql, ids);
         jdbcTemplate.update(getQuery(sql), createParams("incidentCaseIds", ids));
     }
 }


### PR DESCRIPTION
Background, if anyone's interested:

When running in T3, I've just recently started finding that the transaction 'hangs' and I see a blocking session appear in v$session.  I end up having to get the session killed manually.  This used to work ok.

However, I can still successfully point a local instance of Elite2 API to T3 and delete the same offender without problem. 🤷‍♂️ 

I'm hoping that the extra (excessive) logging will help pinpoint why there's an issue!