### PR TITLE
DT-893 tightening up validation on existing scheduling hearing being in future

### DIFF
--- a/src/main/java/net/syscon/elite/service/CourtHearingReschedulingService.java
+++ b/src/main/java/net/syscon/elite/service/CourtHearingReschedulingService.java
@@ -80,7 +80,7 @@ public class CourtHearingReschedulingService {
         final var hearing = courtEventRepository.findById(hearingId).orElseThrow(() -> EntityNotFoundException.withMessage("Court hearing with id '{}' not found.", hearingId));
 
         checkState(hearing.getEventStatus().isScheduled(), "The existing court hearing '%s' must be in a scheduled state to reschedule.", hearingId);
-
+        checkState(hearing.getEventDateTime().isAfter(LocalDateTime.now(clock)), "The existing court hearing '%s' cannot be rescheduled as its start date is in the past.", hearingId);
         return hearing;
     }
 


### PR DESCRIPTION
C-NOMIS has background jobs that expires hearings that are in the past.  However we cannot (should not) rely on this.  This change ensures changes to existing scheduled court hearings can only be done on those with a date already in the future.