### PR TITLE
GDPR-57 Fixing duplicate detection SQL

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/repository/jpa/repository/DuplicateOffenderRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/nomis/datacompliance/repository/jpa/repository/DuplicateOffenderRepository.java
@@ -212,7 +212,7 @@ public interface DuplicateOffenderRepository extends org.springframework.data.re
             "    BIRTH_PLACE_SCORE +" +
             "    ((STREET_SCORE + LOCALITY_SCORE + CITY_CODE_SCORE + COUNTY_CODE_SCORE) / 2) +" +
             "    2 * POSTAL_CODE_SCORE" +
-            "    > 11;",
+            "    > 11",
             nativeQuery = true)
     List<DuplicateOffender> getOffendersWithMatchingDetails(String offenderNo);
 }


### PR DESCRIPTION
When running against an Oracle DB the
extra ';' was causing issues, even though
the integration test against HSQLDB was running
fine.