### PR TITLE
NN-2415: Fix Swagger picking up wrong Visit model

### DIFF
--- a/src/main/java/net/syscon/elite/api/model/VisitWithVisitors.java
+++ b/src/main/java/net/syscon/elite/api/model/VisitWithVisitors.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class VisitWithVisitors<V extends Visit> {
+public class VisitWithVisitors<V extends net.syscon.elite.api.model.Visit> {
     @ApiModelProperty(value = "List of visitors on visit", required = true)
     @JsonProperty("visitors")
     @NotEmpty


### PR DESCRIPTION
Swagger was picking up `v1/Visit` model and generating wrong docs as a result.