### PR TITLE
NN-2738: Fix visit details swagger docs

### DIFF
--- a/src/main/java/net/syscon/elite/api/model/VisitDetails.java
+++ b/src/main/java/net/syscon/elite/api/model/VisitDetails.java
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-public class Visit {
+public class VisitDetails {
 
     @NotBlank
     @ApiModelProperty(required = true, value = "Status of event")

--- a/src/main/java/net/syscon/elite/api/model/VisitWithVisitors.java
+++ b/src/main/java/net/syscon/elite/api/model/VisitWithVisitors.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class VisitWithVisitors<V extends net.syscon.elite.api.model.Visit> {
+public class VisitWithVisitors<V extends VisitDetails> {
     @ApiModelProperty(value = "List of visitors on visit", required = true)
     @JsonProperty("visitors")
     @NotEmpty

--- a/src/main/java/net/syscon/elite/api/resource/BookingResource.java
+++ b/src/main/java/net/syscon/elite/api/resource/BookingResource.java
@@ -51,7 +51,7 @@ import net.syscon.elite.api.model.SentenceDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
 import net.syscon.elite.api.model.UpdateAttendanceBatch;
 import net.syscon.elite.api.model.UpdateCaseNote;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.VisitWithVisitors;
 import net.syscon.elite.api.model.adjudications.AdjudicationSummary;
@@ -515,11 +515,11 @@ public interface BookingResource {
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class, responseContainer = "List"),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class, responseContainer = "List")})
-    Page<VisitWithVisitors<Visit>> getBookingVisitsWithVisitor(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId,
-                                                               @ApiParam(value = "Returned visits must be scheduled on or after this date (in YYYY-MM-DD format).") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "fromDate", required = false) LocalDate fromDate,
-                                                               @ApiParam(value = "Returned visits must be scheduled on or before this date (in YYYY-MM-DD format).") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "toDate", required = false) LocalDate toDate,
-                                                               @ApiParam(value = "Type of visit. One of SCON, OFFI") @RequestParam(value = "visitType", required = false) String visitType,
-                                                               @PageableDefault() final Pageable pageable);
+    Page<VisitWithVisitors<VisitDetails>> getBookingVisitsWithVisitor(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId,
+                                                                      @ApiParam(value = "Returned visits must be scheduled on or after this date (in YYYY-MM-DD format).") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "fromDate", required = false) LocalDate fromDate,
+                                                                      @ApiParam(value = "Returned visits must be scheduled on or before this date (in YYYY-MM-DD format).") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @RequestParam(value = "toDate", required = false) LocalDate toDate,
+                                                                      @ApiParam(value = "Type of visit. One of SCON, OFFI") @RequestParam(value = "visitType", required = false) String visitType,
+                                                                      @PageableDefault() final Pageable pageable);
 
     @GetMapping("/{bookingId}/visits/last")
     @ApiOperation(value = "The most recent visit for the offender.", notes = "The most recent visit for the offender.", nickname = "getBookingVisitsLast")
@@ -527,7 +527,7 @@ public interface BookingResource {
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class)})
-    Visit getBookingVisitsLast(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId);
+    VisitDetails getBookingVisitsLast(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId);
 
     @GetMapping("/{bookingId}/visits/next")
     @ApiOperation(value = "The next visit for the offender.", notes = "The next visit for the offender.", nickname = "getBookingVisitsNext")
@@ -535,7 +535,7 @@ public interface BookingResource {
             @ApiResponse(code = 400, message = "Invalid request.", response = ErrorResponse.class),
             @ApiResponse(code = 404, message = "Requested resource not found.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class)})
-    Visit getBookingVisitsNext(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId);
+    VisitDetails getBookingVisitsNext(@ApiParam(value = "The offender booking id", required = true) @PathVariable("bookingId") Long bookingId);
 
     @GetMapping("/{bookingId}/visits/today")
     @ApiOperation(value = "Today's scheduled visits for offender.", notes = "Today's scheduled visits for offender.", nickname = "getBookingVisitsForToday")

--- a/src/main/java/net/syscon/elite/api/resource/impl/BookingResourceImpl.java
+++ b/src/main/java/net/syscon/elite/api/resource/impl/BookingResourceImpl.java
@@ -47,7 +47,7 @@ import net.syscon.elite.api.model.SentenceDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
 import net.syscon.elite.api.model.UpdateAttendanceBatch;
 import net.syscon.elite.api.model.UpdateCaseNote;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.VisitWithVisitors;
 import net.syscon.elite.api.model.adjudications.AdjudicationSummary;
@@ -593,7 +593,7 @@ public class BookingResourceImpl implements BookingResource {
     }
 
     @Override
-    public Page<VisitWithVisitors<Visit>> getBookingVisitsWithVisitor(final Long bookingId, final LocalDate fromDate, final LocalDate toDate, final String visitType, Pageable pageable) {
+    public Page<VisitWithVisitors<VisitDetails>> getBookingVisitsWithVisitor(final Long bookingId, final LocalDate fromDate, final LocalDate toDate, final String visitType, Pageable pageable) {
         return bookingService.getBookingVisitsWithVisitor(bookingId, fromDate, toDate, visitType, pageable);
     }
 
@@ -624,12 +624,12 @@ public class BookingResourceImpl implements BookingResource {
     }
 
     @Override
-    public Visit getBookingVisitsLast(final Long bookingId) {
+    public VisitDetails getBookingVisitsLast(final Long bookingId) {
         return bookingService.getBookingVisitLast(bookingId);
     }
 
     @Override
-    public Visit getBookingVisitsNext(final Long bookingId) {
+    public VisitDetails getBookingVisitsNext(final Long bookingId) {
         return bookingService.getBookingVisitNext(bookingId);
     }
 

--- a/src/main/java/net/syscon/elite/repository/BookingRepository.java
+++ b/src/main/java/net/syscon/elite/repository/BookingRepository.java
@@ -12,7 +12,7 @@ import net.syscon.elite.api.model.RecallBooking;
 import net.syscon.elite.api.model.ScheduledEvent;
 import net.syscon.elite.api.model.SentenceDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.bulkappointments.AppointmentDefaults;
 import net.syscon.elite.api.model.bulkappointments.AppointmentDetails;
@@ -85,9 +85,9 @@ public interface BookingRepository {
 
     List<OffenderSentenceTerms> getOffenderSentenceTerms(Long bookingId, List<String> sentenceTermCodes);
 
-    Visit getBookingVisitLast(Long bookingId, LocalDateTime cutoffDate);
+    VisitDetails getBookingVisitLast(Long bookingId, LocalDateTime cutoffDate);
 
-    Visit getBookingVisitNext(Long bookingId, LocalDateTime from);
+    VisitDetails getBookingVisitNext(Long bookingId, LocalDateTime from);
 
     Optional<OffenderBookingIdSeq> getLatestBookingIdentifierForOffender(String offenderNo);
 

--- a/src/main/java/net/syscon/elite/repository/impl/BookingRepositoryImpl.java
+++ b/src/main/java/net/syscon/elite/repository/impl/BookingRepositoryImpl.java
@@ -18,7 +18,7 @@ import net.syscon.elite.api.model.RecallBooking;
 import net.syscon.elite.api.model.ScheduledEvent;
 import net.syscon.elite.api.model.SentenceDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.bulkappointments.AppointmentDefaults;
 import net.syscon.elite.api.model.bulkappointments.AppointmentDetails;
@@ -104,8 +104,8 @@ public class BookingRepositoryImpl extends RepositoryBase implements BookingRepo
     private static final StandardBeanPropertyRowMapper<OffenderSentenceTerms> SENTENCE_TERMS_ROW_MAPPER =
             new StandardBeanPropertyRowMapper<>(OffenderSentenceTerms.class);
 
-    private static final StandardBeanPropertyRowMapper<Visit> VISIT_ROW_MAPPER =
-            new StandardBeanPropertyRowMapper<>(Visit.class);
+    private static final StandardBeanPropertyRowMapper<VisitDetails> VISIT_ROW_MAPPER =
+            new StandardBeanPropertyRowMapper<>(VisitDetails.class);
 
     private final StandardBeanPropertyRowMapper<VisitBalances> VISIT_BALANCES_MAPPER =
             new StandardBeanPropertyRowMapper<>(VisitBalances.class);
@@ -490,7 +490,7 @@ public class BookingRepositoryImpl extends RepositoryBase implements BookingRepo
     }
 
     @Override
-    public Visit getBookingVisitLast(final Long bookingId, final LocalDateTime cutoffDate) {
+    public VisitDetails getBookingVisitLast(final Long bookingId, final LocalDateTime cutoffDate) {
         Objects.requireNonNull(bookingId, "bookingId is a required parameter");
         Objects.requireNonNull(cutoffDate, "cutoffDate is a required parameter");
 
@@ -507,7 +507,7 @@ public class BookingRepositoryImpl extends RepositoryBase implements BookingRepo
     }
 
     @Override
-    public Visit getBookingVisitNext(final Long bookingId, final LocalDateTime from) {
+    public VisitDetails getBookingVisitNext(final Long bookingId, final LocalDateTime from) {
         Objects.requireNonNull(bookingId, "bookingId is a required parameter");
         Objects.requireNonNull(from, "from is a required parameter");
 

--- a/src/main/java/net/syscon/elite/service/BookingService.java
+++ b/src/main/java/net/syscon/elite/service/BookingService.java
@@ -22,7 +22,7 @@ import net.syscon.elite.api.model.ScheduledEvent;
 import net.syscon.elite.api.model.SentenceAdjustmentDetail;
 import net.syscon.elite.api.model.SentenceDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.VisitWithVisitors;
 import net.syscon.elite.api.model.Visitor;
@@ -403,7 +403,7 @@ public class BookingService {
     }
 
     @VerifyBookingAccess
-    public Page<VisitWithVisitors<Visit>> getBookingVisitsWithVisitor(final @NotNull Long bookingId, final LocalDate fromDate, final LocalDate toDate, final String visitType, final Pageable pageable) {
+    public Page<VisitWithVisitors<VisitDetails>> getBookingVisitsWithVisitor(final @NotNull Long bookingId, final LocalDate fromDate, final LocalDate toDate, final String visitType, final Pageable pageable) {
         final var visits = visitRepository.findAllByBookingId(bookingId, pageable);
 
         final var visitsWithVisitors = visits.stream()
@@ -426,7 +426,7 @@ public class BookingService {
 
                     return VisitWithVisitors.builder()
                             .visitDetail(
-                                    Visit.builder()
+                                    VisitDetails.builder()
                                             .visitType(v.getVisitType())
                                             .visitTypeDescription(v.getVisitTypeDescription())
                                             .cancellationReason(v.getCancellationReason())
@@ -464,12 +464,12 @@ public class BookingService {
     }
 
     @VerifyBookingAccess(overrideRoles = {"SYSTEM_USER", "GLOBAL_SEARCH"})
-    public Visit getBookingVisitLast(final Long bookingId) {
+    public VisitDetails getBookingVisitLast(final Long bookingId) {
         return bookingRepository.getBookingVisitLast(bookingId, LocalDateTime.now());
     }
 
     @VerifyBookingAccess(overrideRoles = {"SYSTEM_USER", "GLOBAL_SEARCH"})
-    public Visit getBookingVisitNext(final Long bookingId) {
+    public VisitDetails getBookingVisitNext(final Long bookingId) {
         return bookingRepository.getBookingVisitNext(bookingId, LocalDateTime.now());
     }
 

--- a/src/test/java/net/syscon/elite/executablespecification/steps/BookingVisitSteps.java
+++ b/src/test/java/net/syscon/elite/executablespecification/steps/BookingVisitSteps.java
@@ -1,6 +1,6 @@
 package net.syscon.elite.executablespecification.steps;
 
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.support.Order;
 import net.syscon.elite.test.EliteClientException;
 import net.thucydides.core.annotations.Step;
@@ -21,7 +21,7 @@ public class BookingVisitSteps extends ScheduledEventSteps {
     private static final String BOOKING_VISIT_NEXT_API_URL = API_PREFIX + "bookings/{bookingId}/visits/next";
 
 
-    private Visit lastVisit;
+    private VisitDetails lastVisitDetails;
 
     @Override
     protected String getResourcePath() {
@@ -50,16 +50,16 @@ public class BookingVisitSteps extends ScheduledEventSteps {
 
     private void dispatchRequest(final String url, final Long bookingId) {
         init();
-        final ResponseEntity<Visit> response;
+        final ResponseEntity<VisitDetails> response;
         try {
             response = restTemplate.exchange(
                     url,
                     HttpMethod.GET,
                     createEntity(),
-                    new ParameterizedTypeReference<Visit>() {
+                    new ParameterizedTypeReference<VisitDetails>() {
                     },
                     bookingId);
-            lastVisit = response.getBody();
+            lastVisitDetails = response.getBody();
 
         } catch (final EliteClientException ex) {
             setErrorResponse(ex.getErrorResponse());
@@ -67,15 +67,15 @@ public class BookingVisitSteps extends ScheduledEventSteps {
     }
 
     public void verifyVisitField(final String field, final String value) throws ReflectiveOperationException {
-        verifyField(lastVisit, field, value);
+        verifyField(lastVisitDetails, field, value);
     }
 
     public void verifyStartDateTime(final LocalDateTime expectedStartDateTime) {
-        assertThat(lastVisit.getStartTime()).isEqualTo(expectedStartDateTime);
+        assertThat(lastVisitDetails.getStartTime()).isEqualTo(expectedStartDateTime);
     }
 
     public void verifyEndDateTime(final LocalDateTime expectedEndDateTime) {
-        assertThat(lastVisit.getEndTime()).isEqualTo(expectedEndDateTime);
+        assertThat(lastVisitDetails.getEndTime()).isEqualTo(expectedEndDateTime);
 
     }
 }

--- a/src/test/java/net/syscon/elite/repository/BookingRepositoryTest.java
+++ b/src/test/java/net/syscon/elite/repository/BookingRepositoryTest.java
@@ -60,23 +60,23 @@ public class BookingRepositoryTest {
                 .setAuthentication(new TestingAuthenticationToken("itag_user", "password"));
     }
 
-    private static void assertVisitDetails(final Visit visit) {
-        assertThat(visit).isNotNull();
+    private static void assertVisitDetails(final VisitDetails visitDetails) {
+        assertThat(visitDetails).isNotNull();
 
-        assertThat(visit.getStartTime().toString()).isEqualTo("2016-12-11T14:30");
-        assertThat(visit.getEndTime().toString()).isEqualTo("2016-12-11T15:30");
-        assertThat(visit.getEventOutcome()).isEqualTo("ABS");
-        assertThat(visit.getEventOutcomeDescription()).isEqualTo("Absence");
-        assertThat(visit.getLeadVisitor()).isEqualTo("JESSY SMITH1");
-        assertThat(visit.getRelationship()).isEqualTo("UN");
-        assertThat(visit.getRelationshipDescription()).isEqualTo("Uncle");
-        assertThat(visit.getLocation()).isEqualTo("Visiting Room");
-        assertThat(visit.getEventStatus()).isEqualTo("CANC");
-        assertThat(visit.getEventStatusDescription()).isEqualTo("Cancelled");
-        assertThat(visit.getCancellationReason()).isEqualTo("NSHOW");
-        assertThat(visit.getCancelReasonDescription()).isEqualTo("Visitor Did Not Arrive");
-        assertThat(visit.getVisitType()).isEqualTo("SCON");
-        assertThat(visit.getVisitTypeDescription()).isEqualTo("Social Contact");
+        assertThat(visitDetails.getStartTime().toString()).isEqualTo("2016-12-11T14:30");
+        assertThat(visitDetails.getEndTime().toString()).isEqualTo("2016-12-11T15:30");
+        assertThat(visitDetails.getEventOutcome()).isEqualTo("ABS");
+        assertThat(visitDetails.getEventOutcomeDescription()).isEqualTo("Absence");
+        assertThat(visitDetails.getLeadVisitor()).isEqualTo("JESSY SMITH1");
+        assertThat(visitDetails.getRelationship()).isEqualTo("UN");
+        assertThat(visitDetails.getRelationshipDescription()).isEqualTo("Uncle");
+        assertThat(visitDetails.getLocation()).isEqualTo("Visiting Room");
+        assertThat(visitDetails.getEventStatus()).isEqualTo("CANC");
+        assertThat(visitDetails.getEventStatusDescription()).isEqualTo("Cancelled");
+        assertThat(visitDetails.getCancellationReason()).isEqualTo("NSHOW");
+        assertThat(visitDetails.getCancelReasonDescription()).isEqualTo("Visitor Did Not Arrive");
+        assertThat(visitDetails.getVisitType()).isEqualTo("SCON");
+        assertThat(visitDetails.getVisitTypeDescription()).isEqualTo("Social Contact");
     }
 
     @Test

--- a/src/test/java/net/syscon/elite/service/BookingServiceTest.java
+++ b/src/test/java/net/syscon/elite/service/BookingServiceTest.java
@@ -12,7 +12,7 @@ import net.syscon.elite.api.model.PrivilegeDetail;
 import net.syscon.elite.api.model.ScheduledEvent;
 import net.syscon.elite.api.model.SentenceAdjustmentDetail;
 import net.syscon.elite.api.model.UpdateAttendance;
-import net.syscon.elite.api.model.Visit;
+import net.syscon.elite.api.model.VisitDetails;
 import net.syscon.elite.api.model.VisitBalances;
 import net.syscon.elite.api.model.VisitWithVisitors;
 import net.syscon.elite.api.model.Visitor;
@@ -489,7 +489,7 @@ public class BookingServiceTest {
         assertThat(visitsWithVisitors).containsOnly(
                 VisitWithVisitors.builder()
                         .visitDetail(
-                                Visit
+                                VisitDetails
                                         .builder()
                                         .cancellationReason(null)
                                         .cancelReasonDescription(null)
@@ -618,7 +618,7 @@ public class BookingServiceTest {
         assertThat(visitsWithVisitors).containsOnly(
                 VisitWithVisitors.builder()
                         .visitDetail(
-                                Visit
+                                VisitDetails
                                         .builder()
                                         .cancellationReason(null)
                                         .cancelReasonDescription(null)
@@ -657,7 +657,7 @@ public class BookingServiceTest {
                         .build(),
                 VisitWithVisitors.builder()
                         .visitDetail(
-                                Visit
+                                VisitDetails
                                         .builder()
                                         .cancellationReason(null)
                                         .cancelReasonDescription(null)


### PR DESCRIPTION
There were two models called `Visit`, one of which was in `v1`. Swagger was picking up that one anywhere where we use Visit, including in the next and last visit endpoints. That resulted in the generated response docs being wrong, as the those APIs return the elite Visit model.